### PR TITLE
Fix small typo in landing page footer.

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,7 @@
     </div>
     <footer class="df justify-between items-center pa1 pl2-m pr2-m z-2 absolute b0 l0 w-100">
       <a class="tdx white ml-au-m mr1 relative">
-        <span>Made withs Preons</span>
+        <span>Made with Preons</span>
       </a>
     </footer>
   </div>


### PR DESCRIPTION
Saw a typo in the footer on the landing page - _withs_ should be _with_, this PR fixes that issue. 🙂